### PR TITLE
Fixed spelling mistakes of the words "obviously" and "specific"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Unity Package containing all the necessary components to do VR networking with
 [![Discord](https://img.shields.io/badge/Discord-blue.svg)](https://discord.gg/rRvnU846Bf)
 
 # Documentation
-By default everything is set up for a super simple system, obvisouly you can code some stuff yourself to make everything work for your application.
+By default everything is set up for a super simple system, obviously you can code some stuff yourself to make everything work for your application.
 
 You need to have [PUN 2](https://assetstore.unity.com/packages/tools/network/pun-2-free-119922) and [Photon Voice 2](https://assetstore.unity.com/packages/tools/audio/photon-voice-2-130518) in your project before importing this
 You also need TextMeshPro - that's built into unity, you just gotta go into the Player prefab and press Import TMP Essentials.
@@ -116,7 +116,7 @@ PhotonVRManager.SetCosmetics(new PhotonVRCosmeticsData()
 });
 ```
 
-Or if you want to do one at a time (like if you have a button with a specefic cosmetic) then do like so
+Or if you want to do one at a time (like if you have a button with a specific cosmetic) then do like so
 ```cs
 PhotonVRManager.SetCosmetic(CosmeticType.Head, "VRTopHat");
 ```


### PR DESCRIPTION
The readme had a spelling mistake for the words obviously and specific. I fixed those accidental typos. That's the only thing I changed.
obvisouly -> obviously
specefic -> specific